### PR TITLE
Add CI services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: false
+language: python
+python:
+  - "2.7"
+  - "3.6"
+install:
+  - pip install coveralls pytest pytest-cov pycodestyle
+  - pip install -r requirements.txt
+  - pip install -e .
+script:
+  - pycodestyle grift/
+  - py.test --cov=grift grift/tests
+after_success:
+  - coveralls

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,4 +14,4 @@ Each contributor is required to agree to our Contributor License Agreement, to e
 
 ## Style Guide
 
-[Fill out style guide info]
+Make sure your code conforms to style by running `pycodestyle grift/` This should pass with no warnings (see our custom configuration in the `[pycodestyle]` section of `setup.cfg`).

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pycodestyle]
+max-line-length = 100


### PR DESCRIPTION
Enforces a fairly vanilla `pycodestyle`, and runs all tests on travis-ci.org, then sends coverage info to coveralls.io

Will need to activate the project on both services before merging to see it work.