### PR TITLE
Add bandit static analysis as a CI step.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ python:
   - "2.7"
   - "3.6"
 install:
-  - pip install coveralls pytest pytest-cov pycodestyle
+  - pip install bandit coveralls pytest pytest-cov pycodestyle
   - pip install -r requirements.txt
   - pip install -e .
 script:
   - pycodestyle grift/
+  - bandit -r grift/
   - py.test --cov=grift grift/tests
 after_success:
   - coveralls

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,3 +15,5 @@ Each contributor is required to agree to our Contributor License Agreement, to e
 ## Style Guide
 
 Make sure your code conforms to style by running `pycodestyle grift/` This should pass with no warnings (see our custom configuration in the `[pycodestyle]` section of `setup.cfg`).
+
+Use `bandit` to check your code for common Python bugs and security vulnerabilities. Running it as `bandit -r grift/` on the source code of the package should not detect any issues.


### PR DESCRIPTION
Bandit is a Python static analysis tool that uncovers frequent sources of bugs and security vulnerabilities. This PR adds a bandit pass to CI to ensure no such issues make it into the repo.