### PR TITLE
Fix validation of list member type; add test

### DIFF
--- a/grift/property_types.py
+++ b/grift/property_types.py
@@ -54,6 +54,12 @@ class ListType(BaseType):
         to_native = self.member_type.to_native if self.member_type is not None else lambda x: x
         return [to_native(item) for item in value_list]
 
+    def validate_member_type(self, value):
+        """Validate each member of the list, if member_type exists"""
+        if self.member_type:
+            for item in value:
+                self.member_type.validate(item)
+
     def validate_length(self, value):
         """Validate the length of value, if min_length or max_length was specified"""
         list_len = len(value) if value else 0

--- a/grift/tests/test_property_type.py
+++ b/grift/tests/test_property_type.py
@@ -2,7 +2,7 @@
 import unittest
 
 from schematics.exceptions import ConversionError, ValidationError
-from schematics.types import StringType
+from schematics.types import StringType, IntType
 
 from grift.property_types import DictType, ListType, HTTPType
 
@@ -90,6 +90,17 @@ class TestListType(unittest.TestCase):
 
         with self.assertRaises(ValidationError):
             list_type.validate(None)
+
+    def test_validate_member_type(self):
+        list_type = ListType(member_type=IntType(choices=[1, 2]))
+
+        list_type.validate([1, 2])
+
+        with self.assertRaises(ConversionError):
+            list_type.validate(['a', 'b'])
+
+        with self.assertRaises(ValidationError):
+            list_type.validate([1, 3])
 
 
 class TestHTTPType(unittest.TestCase):


### PR DESCRIPTION
Currently, only using the `to_native` schematics function to check list members for ListType. This schematics method converts the data type, catching some conversion errors, but it's not the full validation.