### PR TITLE
Add loaders for Vault compatibility

### DIFF
--- a/grift/loaders.py
+++ b/grift/loaders.py
@@ -3,6 +3,8 @@ from abc import ABCMeta, abstractmethod
 import json
 import os
 
+import requests
+
 
 class AbstractLoader(object):
     """Base class for loading configuration settings from a source"""
@@ -65,6 +67,87 @@ class EnvLoader(DictLoader):
     def reload(self):
         """Read in values from the env"""
         self._source = os.environ
+
+
+class VaultTokenLoader(DictLoader):
+    def __init__(self, url, path, token):
+        """Load secrets from a Vault path, using token authentication
+
+        See https://www.vaultproject.io/docs
+
+        Args:
+            url: Vault url
+            path: Vault path to fetch secrets from
+            vault_token: token (must have access to vault path)
+        """
+        self._vault_url = url
+        self._path = path
+        self._token = token
+        source_dict = self._fetch_secrets()
+        super(VaultTokenLoader, self).__init__(source_dict)
+
+    @property
+    def _headers(self):
+        """Return token header to access vault"""
+        return {'X-Vault-Token': self._token}
+
+    def _fetch_secrets(self):
+        """Read data from the vault path"""
+        url = '{}/v1/{}'.format(self._vault_url, self._path)
+        resp = requests.get(url, headers=self._headers)
+        resp.raise_for_status()
+        data = resp.json()
+        return data['data']
+
+    def reload(self):
+        """Reread secrets from the vault path"""
+        self._source = self._fetch_secrets()
+
+    def lookup_token(self):
+        """Convenience method: look up the vault token"""
+        url = '{}/v1/auth/token/lookup-self'.format(self._vault_url)
+        resp = requests.get(url, headers=self._headers)
+        resp.raise_for_status()
+        data = resp.json()
+        if data.get('errors'):
+            raise ValueError(u'Error looking up vault token: {}'.format(data['errors']))
+        return data
+
+    def renew_token(self):
+        """Convenience method: renew vault token"""
+        url = '{}/v1/auth/token/renew-self'.format(self._vault_url)
+        resp = requests.get(url, headers=self._headers)
+        resp.raise_for_status()
+        data = resp.json()
+        if data.get('errors'):
+            raise ValueError(u'Error renewing vault token: {}'.format(data['errors']))
+        return data
+
+
+class VaultAppRoleLoader(VaultTokenLoader):
+    def __init__(self, url, path, role_id, secret_id):
+        """Load secrets from a Vault path, using the AppRole auth backend
+
+        See https://www.vaultproject.io/docs/auth/approle.html
+
+        Args:
+            url: Vault url
+            path: Vault path to fetch secrets from
+            role_id: Vault RoleID
+            secret_id: Vault SecretID
+        """
+        self._role_id = role_id
+        self._secret_id = secret_id
+        token = self._fetch_token()
+        super(VaultAppRoleLoader, self).__init__(url, path, token=token)
+
+    def _fetch_token(self):
+        """Get a Vault token, using the RoleID and SecretID"""
+        url = '{}/v1/auth/approle/login'.format(self._vault_url)
+        resp = requests.post(url, data={'role_id': self._role_id, 'secret_id': self._secret_id})
+        resp.raise_for_status()
+        data = resp.json()
+        return data['auth']['client_token']
 
 
 # Default loaders, for convenience. Prefers the EnvLoader (env vars), with a fallback on a json

--- a/grift/tests/test_loaders.py
+++ b/grift/tests/test_loaders.py
@@ -1,0 +1,138 @@
+import mock
+import os
+from unittest import TestCase
+
+from grift.loaders import JsonFileLoader, EnvLoader, DictLoader, VaultTokenLoader, VaultException
+from grift.utils import in_same_dir
+
+SAMPLE_FILE_PATH = in_same_dir(__file__, 'sample_config.json')
+
+
+class TestBasicLoaders(TestCase):
+
+    def test_dict_loader(self):
+        config_dict = {
+            'KEY': 'value',
+            'foo': 'bar'
+        }
+
+        loader = DictLoader(config_dict)
+        self.assertTrue(loader.exists('KEY'))
+        self.assertTrue('KEY' in loader)
+        self.assertTrue(loader.exists('foo'))
+        self.assertTrue('foo' in loader)
+        self.assertFalse(loader.exists('bar'))
+        self.assertFalse('bar' in loader)
+
+        self.assertEqual(loader.get('KEY'), 'value')
+        self.assertEqual(loader.get('foo'), 'bar')
+
+    def test_env_loader(self):
+        os.environ['EXISTING_KEY'] = 'hello'
+
+        loader = EnvLoader()
+
+        # change the env after loader is initialized
+        os.environ['EXISTING_KEY'] = 'world'
+        os.environ['NEW_KEY'] = 'brand_new'
+
+        self.assertTrue(loader.exists('EXISTING_KEY'))
+        self.assertTrue(loader.exists('NEW_KEY'))
+        self.assertFalse(loader.exists('BAD_KEY'))
+
+        self.assertEqual(loader.get('EXISTING_KEY'), 'world')
+        self.assertEqual(loader.get('NEW_KEY'), 'brand_new')
+
+    def test_json_file_loader(self):
+        loader = JsonFileLoader(SAMPLE_FILE_PATH)
+        self.assertTrue(loader.exists('STRING_PROP'))
+        self.assertTrue(loader.exists('INT_PROP'))
+        self.assertFalse(loader.exists('BAD_PROPERTY_NAME'))
+
+        self.assertEqual(loader.get('STRING_PROP'), '1')
+        self.assertEqual(loader.get('INT_PROP'), '2')  # unconverted type
+        self.assertEqual(loader.get('ANY_TYPE_PROP'), [1, 2, 3])
+
+
+def _mock_response(json_resp):
+    """Return a mock class that returns json_resp when .json() is called (for requests.get)"""
+    mock_resp = mock.MagicMock()
+    mock_resp.json = mock.MagicMock(return_value=json_resp)
+    return mock_resp
+
+
+class TestVaultLoader(TestCase):
+    """Testing logic of accessing Vault via http requests; heavily mocked"""
+
+    def setUp(self):
+        self.url = 'fake_vault_url'
+        self.path = 'fake_vault_path'
+        self.token = 'fake_token'
+
+        self.expected_header = {'X-Vault-Token': self.token}
+
+    def test_token_fetch_secrets(self):
+        secrets = {
+            'hello': 'world',
+            'foo': 'bar'
+        }
+
+        expected_url = '{}/v1/{}'.format(self.url, self.path)
+
+        with mock.patch('requests.get', return_value=_mock_response({'data': secrets})) as mock_get:
+            loader = VaultTokenLoader(self.url, self.path, self.token)
+
+            mock_get.assert_called_once_with(expected_url, headers=self.expected_header)
+
+            self.assertTrue(loader.exists('hello'))
+            self.assertTrue(loader.exists('foo'))
+            self.assertFalse(loader.exists('bad-key'))
+
+            self.assertEqual(loader.get('hello'), 'world')
+            self.assertEqual(loader.get('foo'), 'bar')
+
+    def test_lookup_token(self):
+        expected_url = '{}/v1/auth/token/lookup-self'.format(self.url)
+
+        with mock.patch('requests.get', return_value=_mock_response({'data': {}})):
+            loader = VaultTokenLoader(self.url, self.path, self.token)
+
+        with mock.patch('requests.get', return_value=_mock_response({'foo': 'bar'})) as mock_get:
+            resp = loader.lookup_token()
+            mock_get.assert_called_once_with(expected_url, headers=self.expected_header)
+
+            self.assertDictEqual(resp, {'foo': 'bar'})
+
+    def test_lookup_token_fail(self):
+        expected_url = '{}/v1/auth/token/lookup-self'.format(self.url)
+
+        with mock.patch('requests.get', return_value=_mock_response({'data': {}})):
+            loader = VaultTokenLoader(self.url, self.path, self.token)
+
+        with mock.patch('requests.get', return_value=_mock_response({'errors': 'foo'})) as mock_get:
+            with self.assertRaises(VaultException):
+                loader.lookup_token()
+
+            mock_get.assert_called_once_with(expected_url, headers=self.expected_header)
+
+    def test_renew_token(self):
+        expected_url = '{}/v1/auth/token/renew-self'.format(self.url)
+
+        with mock.patch('requests.get', return_value=_mock_response({'data': {}})):
+            loader = VaultTokenLoader(self.url, self.path, self.token)
+
+        with mock.patch('requests.get', return_value=_mock_response({'foo': 'bar'})) as mock_get:
+            loader.renew_token()
+            mock_get.assert_called_once_with(expected_url, headers=self.expected_header)
+
+    def test_renew_token_fail(self):
+        expected_url = '{}/v1/auth/token/renew-self'.format(self.url)
+
+        with mock.patch('requests.get', return_value=_mock_response({'data': {}})):
+            loader = VaultTokenLoader(self.url, self.path, self.token)
+
+        with mock.patch('requests.get', return_value=_mock_response({'errors': 'foo'})) as mock_get:
+            with self.assertRaises(VaultException):
+                loader.renew_token()
+
+            mock_get.assert_called_once_with(expected_url, headers=self.expected_header)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+# These requirements are used for testing and development; please update setup.py if needed
 requests>=2.7.0
 schematics==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # These requirements are used for testing and development; please update setup.py if needed
+mock>=2.0.0
 requests>=2.7.0
 schematics==1.1.1

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(name=package_name,
       packages=find_packages(),
       package_data={package_name + '.tests': ['*.json']},
       install_requires=[
-          'schematics==1.1.1'
+          'schematics==1.1.1',
+          'requests==2.13.0'
       ],
       )


### PR DESCRIPTION
Adding two loaders to support reading secrets from a path in a Vault. For now, supporting authentication via [token]( https://www.vaultproject.io/docs/concepts/tokens.html) (which is what all other auth backends map to) or [app role](https://www.vaultproject.io/docs/auth/approle.html). 

I also included a few convenience methods in the token loader, to look up info about the token or renew it. The renewal method could be run periodically by a task or cronjob to keep a running service's token from expiring, in case the service is restarted / secrets need to be reloaded.

Would appreciate input on all of this -- I've been toying with Vault locally, but haven't worked with it in production.